### PR TITLE
fix: restore MDX plugin pipeline for mdx-bundler v10

### DIFF
--- a/lib/mdx.js
+++ b/lib/mdx.js
@@ -60,7 +60,7 @@ export async function getFileBySlug(type, slug) {
     source,
     // mdx imports can be automatically source from the components directory
     cwd: path.join(root, 'components'),
-    xdmOptions(options, frontmatter) {
+    mdxOptions(options, frontmatter) {
       // this is the recommended way to add custom remark/rehype plugins:
       // The syntax might look weird, but it protects you in case we add/remove
       // plugins in the future.

--- a/lib/remark-img-to-jsx.js
+++ b/lib/remark-img-to-jsx.js
@@ -1,5 +1,5 @@
 import { visit } from 'unist-util-visit'
-import sizeOf from 'image-size'
+import { imageSize } from 'image-size'
 import fs from 'fs'
 
 export default function remarkImgToJsx() {
@@ -12,8 +12,9 @@ export default function remarkImgToJsx() {
         const imageNode = node.children.find((n) => n.type === 'image')
 
         // only local files
-        if (fs.existsSync(`${process.cwd()}/public${imageNode.url}`)) {
-          const dimensions = sizeOf(`${process.cwd()}/public${imageNode.url}`)
+        const imagePath = `${process.cwd()}/public${imageNode.url}`
+        if (fs.existsSync(imagePath)) {
+          const dimensions = imageSize(fs.readFileSync(imagePath))
 
           // Convert original node to next/image
           ;(imageNode.type = 'mdxJsxFlowElement'),


### PR DESCRIPTION
## Summary
- Rename `xdmOptions` to `mdxOptions` in `lib/mdx.js` for `mdx-bundler@10` compatibility — old name was silently ignored, causing all remark/rehype plugins (including `remark-gfm` for table parsing) to never apply
- Update `lib/remark-img-to-jsx.js` for `image-size@2` API change — use named `imageSize` export with Buffer input instead of removed default export with file path

## Test plan
- [x] `npm run build` passes with all plugins restored
- [x] About page renders 3 markdown tables as `<table>` elements (previously rendered as raw pipe text in `<p>` tags)
- [ ] Verify table styling in browser (prose/dark mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)