### PR TITLE
fix: restore MDX plugin pipeline for mdx-bundler v10

### DIFF
--- a/lib/mdx.js
+++ b/lib/mdx.js
@@ -60,7 +60,7 @@ export async function getFileBySlug(type, slug) {
     source,
     // mdx imports can be automatically source from the components directory
     cwd: path.join(root, 'components'),
-    xdmOptions(options, frontmatter) {
+    mdxOptions(options, frontmatter) {
       // this is the recommended way to add custom remark/rehype plugins:
       // The syntax might look weird, but it protects you in case we add/remove
       // plugins in the future.

--- a/lib/remark-img-to-jsx.js
+++ b/lib/remark-img-to-jsx.js
@@ -1,5 +1,5 @@
 import { visit } from 'unist-util-visit'
-import sizeOf from 'image-size'
+import { imageSize } from 'image-size'
 import fs from 'fs'
 
 export default function remarkImgToJsx() {
@@ -12,8 +12,9 @@ export default function remarkImgToJsx() {
         const imageNode = node.children.find((n) => n.type === 'image')
 
         // only local files
-        if (fs.existsSync(`${process.cwd()}/public${imageNode.url}`)) {
-          const dimensions = sizeOf(`${process.cwd()}/public${imageNode.url}`)
+        const imagePath = `${process.cwd()}/public${imageNode.url}`
+        if (fs.existsSync(imagePath)) {
+          const dimensions = imageSize(fs.readFileSync(imagePath))
 
           // Convert original node to next/image
           ;(imageNode.type = 'mdxJsxFlowElement'),


### PR DESCRIPTION
mdx-bundler@10 renamed xdmOptions to mdxOptions, causing all remark/rehype plugins to be silently ignored. This broke GFM table rendering and other markdown features.

Also update remark-img-to-jsx for image-size@2 API change — now requires Buffer input via named imageSize export.